### PR TITLE
Feature/login

### DIFF
--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -48,7 +48,7 @@ class LoginTest extends TestCase
      * A user can not be logged in successfully with a invalid credentials
      *
      */
-    public function test_a_user_can_not_be_logged_in(): void
+    public function test_a_user_can_not_be_logged_in_with_both_fields_wrong(): void
     {
         \Artisan::call('passport:install');
 
@@ -78,7 +78,7 @@ class LoginTest extends TestCase
     }
     
     /**
-     * A user cannot be logged in successfully with missing fields
+     * A user can not be logged in successfully with missing fields
      *
      */
     public function test_a_user_cannot_be_logged_in_with_missing_fields(): void
@@ -88,4 +88,37 @@ class LoginTest extends TestCase
         $response->assertStatus(422);
         
     }
+
+    /**
+     * A user can not be logged in successfully with an incorrect password
+     */
+    public function test_a_user_cannot_be_logged_in_with_wrong_password(): void
+    {
+        \Artisan::call('passport:install');
+
+        User::create([
+            'name' => 'Gabriela',
+            'email' => 'gaby@gmail.com',
+            'dni' => '39986946S',
+            'password' => bcrypt('password'),
+            'status' => 'ACTIVE',
+            'role' => 'ADMIN',
+        ]);
+
+        $response = $this->postJson(route('login'), [
+            'dni' => '39986946S',
+            'password' => 'wrongPassword'
+        ]);
+        
+        $response->assertStatus(401);
+        $response->assertJson([
+            'result' => [
+                'message' => 'Invalid credentials'
+            ],
+            'status' => false
+        ]);
+
+        $this->assertGuest();
+    }
+
 }

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -77,4 +77,15 @@ class LoginTest extends TestCase
         $this->assertGuest();
     }
     
+    /**
+     * A user cannot be logged in successfully with missing fields
+     *
+     */
+    public function test_a_user_cannot_be_logged_in_with_missing_fields(): void
+    {
+        $response = $this->postJson(route('login'), []);
+        
+        $response->assertStatus(422);
+        
+    }
 }

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -121,4 +121,37 @@ class LoginTest extends TestCase
         $this->assertGuest();
     }
 
+    /**
+     * A user cannot be logged in successfully with an incorrect DNI
+     */
+    public function test_a_user_cannot_be_logged_in_with_wrong_dni(): void
+    {
+        \Artisan::call('passport:install');
+
+        User::create([
+            'name' => 'Gabriela',
+            'email' => 'gaby@gmail.com',
+            'dni' => '39986946S',
+            'password' => bcrypt('password'),
+            'status' => 'ACTIVE',
+            'role' => 'ADMIN',
+        ]);
+
+        $response = $this->postJson(route('login'), [
+            'dni' => '39986987N',
+            'password' => 'password'
+        ]);
+        
+        $response->assertStatus(401);
+        $response->assertJson([
+            'result' => [
+                'message' => 'Invalid credentials'
+            ],
+            'status' => false
+        ]);
+
+        $this->assertGuest();
+    }
+
+
 }


### PR DESCRIPTION
Added 3 more methods:
1. **test_a_user_cannot_be_logged_in_with_missing_fields**: A login request is made without providing any data, and the response is expected to have a status code of 422, indicating that required fields are missing.
2. **test_a_user_cannot_be_logged_in_with_wrong_password:** A user is created in the database with a valid password and a login request is made with an incorrect password. The response is expected to have a 401 status code and a message indicating "Invalid credentials". And is verified that the user is not authenticated.
3. test_a_user_cannot_be_logged_in_with_wrong_dni: The same as the previous method but this time the request is made with a wrong 'dni'

